### PR TITLE
#218 他サイトでの埋め込み(iframe)用のページの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # qlist iframe Plugin
 
 ## Description
-Question list for iframet tag.
+Question list for iframe tag.

--- a/list.php
+++ b/list.php
@@ -1,0 +1,43 @@
+<?php
+
+	if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+		header('Location: ../');
+		exit;
+	}
+
+	require_once QA_INCLUDE_DIR.'db/selects.php';
+	require_once QA_INCLUDE_DIR.'app/format.php';
+	require_once QA_INCLUDE_DIR.'app/updates.php';
+
+	$tag = qa_request_part(2); // picked up from qa-page.php
+	$userid = null;
+
+//	Find the questions with this tag
+
+	$selectspec = qa_db_tag_recent_qs_selectspec($userid, $tag, 0, false, 5);
+	$selectspec['source'] .= " WHERE ^posts.acount >= 1";
+	$questions = qa_db_select_with_pending( $selectspec );
+
+	$usershtml = qa_userids_handles_html($questions);
+
+//	Prepare content for theme
+
+	$qa_content = qa_content_prepare(true);
+
+	// $qa_content['title'] = qa_lang_html_sub('main/questions_tagged_x', qa_html($tag));
+
+	if (!count($questions)) {
+		$qa_content['q_list']['title'] = qa_lang_html('main/no_questions_found');
+	}
+
+	$qa_content['q_list']['qs'] = array();
+	foreach ($questions as $postid => $question) {
+		$qa_content['q_list']['qs'][] = qa_post_html_fields($question, $userid, qa_cookie_get(), $usershtml, null, qa_post_html_options($question));
+	}
+
+	return $qa_content;
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/list.php
+++ b/list.php
@@ -8,16 +8,25 @@
 	require_once QA_INCLUDE_DIR.'db/selects.php';
 	require_once QA_INCLUDE_DIR.'app/format.php';
 	require_once QA_INCLUDE_DIR.'app/updates.php';
+	require_once QA_INCLUDE_DIR.'util/string.php';
 
 	$tag = qa_request_part(2); // picked up from qa-page.php
 	$userid = null;
 
 //	Find the questions with this tag
 
-	$selectspec = qa_db_tag_recent_qs_selectspec($userid, $tag, 0, false, 5);
-	$selectspec['source'] .= " WHERE ^posts.acount >= 1";
-	$questions = qa_db_select_with_pending( $selectspec );
+	$selectspec=qa_db_posts_basic_selectspec($userid, false);
 
+	// use two tests here - one which can use the index, and the other which narrows it down exactly - then limit to 1 just in case
+	$selectspec['source'] .= " JOIN (SELECT postid FROM ^posttags WHERE wordid=(SELECT wordid FROM ^words WHERE word=$ AND word=$ COLLATE utf8_bin LIMIT 1) ORDER BY postcreated DESC) y ON ^posts.postid=y.postid";
+	$selectspec['source'] .= " WHERE ^posts.acount >= 1";
+	array_push($selectspec['arguments'], $tag, qa_strtolower($tag));
+	$selectspec['sortdesc']='created';
+
+	// $selectspec = qa_db_tag_recent_qs_selectspec($userid, $tag, 0, false, 5);
+	$questions = qa_db_select_with_pending( $selectspec );
+	$questions = array_slice($questions, 0, 5);
+	// error_log('questions selectspec: ' . serialize($selectspec));
 	$usershtml = qa_userids_handles_html($questions);
 
 //	Prepare content for theme

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -19,4 +19,6 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 }
 
 // page
-qa_register_plugin_module('page', 'qa-test-page.php', 'qa_test_page', 'Test Page');
+qa_register_plugin_module('page', 'qa-qlist-iframe-page.php', 'qa_qlist_iframe_page', 'QList iframe Page');
+// layer
+qa_register_plugin_layer('qa-qlist-iframe-layer.php','QList iframe Layer');

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+	Plugin Name: QList iframe Plugin
+	Plugin URI:
+	Plugin Description: Question List for iframe
+	Plugin Version: 1.0
+	Plugin Date: 2016-09-15
+	Plugin Author: 38qa.net
+	Plugin Author URI: http://38qa.net/
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// page
+qa_register_plugin_module('page', 'qa-test-page.php', 'qa_test_page', 'Test Page');

--- a/qa-qlist-iframe-layer.php
+++ b/qa-qlist-iframe-layer.php
@@ -6,12 +6,14 @@ class qa_html_theme_layer extends qa_html_theme_base
 
 	public function body()
 	{
-		unset($this->content['navigation']);
-		unset($this->content['sidebar']);
-		unset($this->content['sidepanel']);
-		unset($this->content['widgets']);
-		unset($this->content['logo']);
-		unset($this->content['search']);
+		if ($this->template === 'iframe') {
+			unset($this->content['navigation']);
+			unset($this->content['sidebar']);
+			unset($this->content['sidepanel']);
+			unset($this->content['widgets']);
+			unset($this->content['logo']);
+			unset($this->content['search']);
+		}
 		qa_html_theme_base::body();
 	}
 

--- a/qa-qlist-iframe-layer.php
+++ b/qa-qlist-iframe-layer.php
@@ -1,0 +1,118 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+
+
+	public function body()
+	{
+		unset($this->content['navigation']);
+		unset($this->content['sidebar']);
+		unset($this->content['sidepanel']);
+		unset($this->content['widgets']);
+		unset($this->content['logo']);
+		unset($this->content['search']);
+		qa_html_theme_base::body();
+	}
+
+	public function body_header()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::body_header();
+	}
+
+	public function body_footer()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::body_footer();
+	}
+
+	public function body_hidden()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::body_hidden();
+	}
+
+	public function header()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::header();
+	}
+
+	public function footer()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::footer();
+	}
+
+	public function body_suffix()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::body_suffix();
+	}
+
+	public function sidepanel()
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::sidepanel();
+	}
+
+	public function widgets($region, $place)
+	{
+		if ($this->template === 'iframe') {
+			return;
+		}
+		qa_html_theme_base::widgets($region, $place);
+	}
+
+
+	public function body_tags()
+	{
+		if ($this->template === 'iframe') {
+			$this->output(' style="background:white;" ');
+		}
+		qa_html_theme_base::body_tags();
+	}
+
+	public function head_script()
+	{
+		if ($this->template === 'iframe') {
+			if (isset($this->content['script'])) {
+				foreach ($this->content['script'] as $scriptline)
+					$this->output_raw($scriptline);
+			}
+			return;
+		}
+		qa_html_theme_base::head_script();
+	}
+
+	public function body_script()
+	{
+		qa_html_theme_base::body_script();
+		if ($this->template === 'iframe') {
+			$script = <<<EOS
+<script>
+$(document).ready(function(){
+	$('a').attr('target', '_blank');
+});
+</script>
+EOS;
+			$this->output($script);
+		}
+	}
+
+}

--- a/qa-qlist-iframe-page.php
+++ b/qa-qlist-iframe-page.php
@@ -1,0 +1,58 @@
+<?php
+
+class qa_qlist_iframe_page {
+
+	var $directory;
+	var $urltoroot;
+
+
+	function load_module($directory, $urltoroot)
+	{
+		$this->directory=$directory;
+		$this->urltoroot=$urltoroot;
+	}
+
+
+	function suggest_requests() // for display in admin interface
+	{
+		return array(
+			array(
+				'title' => 'QList iframe',
+				'request' => 'iframe',
+				'nav' => 'none', // 'M'=main, 'F'=footer, 'B'=before main, 'O'=opposite main, null=none
+			),
+		);
+	}
+
+
+	function match_request($request)
+	{
+		$requestparts = qa_request_parts();
+
+		return ( !empty( $requestparts )
+			&& @$requestparts[0] === 'iframe'
+			&& @$requestparts[1] === 'list'
+			&& !empty( $requestparts[2] )
+		);
+	}
+
+
+	function process_request($request)
+	{
+		$tag = qa_request_part(2);
+
+		if ( !strlen( $tag ) ) {
+			return include QA_INCLUDE_DIR . 'qa-page-not-found.php';
+		}
+
+		qa_set_template( 'iframe' );
+
+		return require QA_PLUGIN_DIR . '/q2a-qlist-iframe/list.php';
+	}
+
+}
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/


### PR DESCRIPTION
- URL `/iframe/list/{tag}`
  - 例 : https://dev.38qa.net/iframe/list/分蜂
- 最新5件を表示
- リンクには target='_blank' 指定

layer が少し冗長な書き方になってますが、ほかのプラグインでも layer を使用してカスタマイズすることがあるので、表示したくない部分はテンプレートを確認して処理を飛ばすほうが確実なのでこうなりました。
